### PR TITLE
Python3 compatibility

### DIFF
--- a/opengraph/__init__.py
+++ b/opengraph/__init__.py
@@ -1,1 +1,1 @@
-from opengraph import OpenGraph
+from .opengraph import OpenGraph

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -1,7 +1,12 @@
 # encoding: utf-8
 
 import re
-import urllib2
+
+try:
+    import urllib2
+except ImportError:
+    from urllib import request as urllib2
+
 try:
     from bs4 import BeautifulSoup
 except ImportError:
@@ -29,12 +34,12 @@ class OpenGraph(dict):
 
         for k in kwargs.keys():
             self[k] = kwargs[k]
-        
+
         dict.__init__(self)
-                
+
         if url is not None:
             self.fetch(url)
-            
+
         if html is not None:
             self.parser(html)
 
@@ -43,14 +48,14 @@ class OpenGraph(dict):
 
     def __getattr__(self, name):
         return self[name]
-            
+
     def fetch(self, url):
         """
         """
         raw = urllib2.urlopen(url)
         html = raw.read()
         return self.parser(html)
-        
+
     def parser(self, html):
         """
         """
@@ -72,22 +77,22 @@ class OpenGraph(dict):
                         pass
 
     def valid_attr(self, attr):
-        return hasattr(self, attr) and len(self[attr]) > 0
+        return self.get(attr) and len(self[attr]) > 0
 
     def is_valid(self):
         return all([self.valid_attr(attr) for attr in self.required_attrs])
-        
+
     def to_html(self):
         if not self.is_valid():
             return u"<meta property=\"og:error\" content=\"og metadata is not valid\" />"
-            
+
         meta = u""
         for key,value in self.iteritems():
             meta += u"\n<meta property=\"og:%s\" content=\"%s\" />" %(key, value)
         meta += u"\n"
-        
+
         return meta
-        
+
     def to_json(self):
         # TODO: force unicode
         global import_json
@@ -96,9 +101,9 @@ class OpenGraph(dict):
 
         if not self.is_valid():
             return json.dumps({'error':'og metadata is not valid'})
-            
+
         return json.dumps(self)
-        
+
     def to_xml(self):
         pass
 

--- a/opengraph/test.py
+++ b/opengraph/test.py
@@ -3,7 +3,6 @@
 import unittest
 import opengraph
 
-
 HTML = """
 <html xmlns:og="http://ogp.me/ns#">
 <head>
@@ -17,31 +16,34 @@ HTML = """
 """
 
 class test(unittest.TestCase):
-		
+
     def test_url(self):
-        data = opengraph.OpenGraph(url='http://vimeo.com/896837')
-        self.assertEqual(data['url'], 'http://vimeo.com/896837')
-        
+        data = opengraph.OpenGraph(url='https://vimeo.com/896837')
+        self.assertEqual(data['url'], 'https://vimeo.com/896837')
+
     def test_isinstace(self):
         data = opengraph.OpenGraph()
         self.assertTrue(isinstance(data,dict))
-        
+
     def test_to_html(self):
         og = opengraph.OpenGraph(html=HTML)
         self.assertTrue(og.to_html())
 
     def test_to_json(self):
-        og = opengraph.OpenGraph(url='http://www.youtube.com/watch?v=XAyNT2bTFuI')
+        og = opengraph.OpenGraph(url='https://www.youtube.com/watch?v=XAyNT2bTFuI')
         self.assertTrue(og.to_json())
         self.assertTrue(isinstance(og.to_json(),str))
 
     def test_no_json(self):
-        opengraph.import_json = False
-        og = opengraph.OpenGraph(url='http://grooveshark.com')
+        if getattr(opengraph, 'import_json', None) is not None:  # python2
+            opengraph.import_json = False
+        else:  # python3
+            opengraph.opengraph.import_json = False
+        og = opengraph.OpenGraph(url='http://www.ogp.me/')
         self.assertEqual(og.to_json(),"{'error':'there isn't json module'}")
-        
+
     def test_is_valid(self):
-        og = opengraph.OpenGraph(url='http://grooveshark.com')
+        og = opengraph.OpenGraph(url='http://www.ogp.me/')
         self.assertTrue(og.is_valid())
 
 


### PR DESCRIPTION
Fixes are manual rather than using the 2to3 tool. Inspired by: https://github.com/AhnSeongHyun/opengraph and https://github.com/lerina/opengraph/commit/353e39b44600cb3560d6cebbc655a765c5933f1f

Also tested that still works with python 2.7.

Couldn't easily try with python 2.6, but don't see any reason why it shouldn't work.
